### PR TITLE
fix: remove more ads fields

### DIFF
--- a/source_facebook_pages/manifest.yaml
+++ b/source_facebook_pages/manifest.yaml
@@ -68,24 +68,10 @@ definitions:
         $ref: "#/definitions/requester"
         request_parameters:
           fields: |
-            {{ 
+            {{
               ','.join([
               'id',
               'about',
-              'ad_campaign',
-              'affiliation',
-              'app_id',
-              'artists_we_like',
-              'attire',
-              'awards',
-              'band_interests',
-              'band_members',
-              'bio',
-              'birthday',
-              'booking_agent',
-              'built',
-              'can_checkin',
-              'can_post',
               'category',
               'category_list',
               'checkins',
@@ -93,13 +79,8 @@ definitions:
               'contact_address',
               'country_page_likes',
               'cover',
-              'culinary_team',
-              'current_location',
-              'delivery_and_pickup_option_info',
               'description',
               'description_html',
-              'differently_open_offerings',
-              'directed_by',
               'display_subtext',
               'displayed_message_response_time',
               'emails',
@@ -113,12 +94,6 @@ definitions:
               'general_info',
               'general_manager',
               'genre',
-              'global_brand_page_name',
-              'global_brand_root_id',
-              'has_added_app',
-              'has_transitioned_to_new_page_experience',
-              'has_whatsapp_business_number',
-              'has_whatsapp_number',
               'hometown',
               'hours',
               'impressum',
@@ -126,9 +101,6 @@ definitions:
               'is_always_open',
               'is_chain',
               'is_community_page',
-              'is_eligible_for_branded_content',
-              'is_messenger_bot_get_started_enabled',
-              'is_messenger_platform_bot',
               'is_owned',
               'is_permanently_closed',
               'is_published',
@@ -141,9 +113,6 @@ definitions:
               'location',
               'members',
               'merchant_review_status',
-              'messenger_ads_default_icebreakers',
-              'messenger_ads_default_quick_replies',
-              'messenger_ads_quick_replies_type',
               'mission',
               'mpg',
               'name',
@@ -185,7 +154,6 @@ definitions:
               'store_location_descriptor',
               'store_number',
               'studio',
-              'supports_donate_button_in_live_video',
               'talking_about_count',
               'temporary_status',
               'unread_message_count',
@@ -207,13 +175,11 @@ definitions:
               'image_copyrights',
               'indexed_videos',
               'likes',
-              'live_videos',
               'photos',
               'product_catalogs',
-              'rtb_dynamic_posts',
               'video_lists',
               'videos',
-              ]) 
+              ])
             }}
 
   post_stream:
@@ -230,7 +196,7 @@ definitions:
         $ref: "#/definitions/requester"
         request_parameters:
           fields: |
-            {{ 
+            {{
               ','.join([
               'id',
               'feed_targeting',
@@ -262,7 +228,7 @@ definitions:
         $ref: "#/definitions/requester"
         request_parameters:
           fields: |
-            {{ 
+            {{
               'insights.metric(%s)' % ','.join([
               'post_impressions',
               'post_impressions_unique',


### PR DESCRIPTION
This is not the most scientific approach, but we had a few ads fields that weren't removed from the manifest. A bit of whackamole because the individual fields, and their required perms, are not listed clearly in the API docs.

The reason this worked in dev and not prod is because I had manually unchecked a bunch of fields in the connection's streams page. Rather than do that by hand, again, there are two options:

1. This PR
2. Import the dev connection and source into Octavia, duplicate it, push to prod

I chose #1, but you could have also done #2 to match the configurations between dev and prod 100%.
